### PR TITLE
tables for revenue

### DIFF
--- a/Database/Table Scripts/RofDatamart/dbo.RofRevenueByDate.sql
+++ b/Database/Table Scripts/RofDatamart/dbo.RofRevenueByDate.sql
@@ -1,0 +1,16 @@
+USE [RofDatamart];
+GO
+
+IF (EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'RofRevenueByDate'))
+BEGIN
+	DROP TABLE dbo.RofRevenueByDate;
+END
+
+CREATE TABLE dbo.RofRevenueByDate
+(	
+	RevenueDate DATE NOT NULL,
+	RevenueMonth SMALLINT NOT NULL,
+	RevenueYear SMALLINT NOT NULL, 
+	GrossRevenue DECIMAL(10, 2) NOT NULL,
+	NetRevenuePostEmployeePay DECIMAL(10, 2) NOT NULL
+);

--- a/Database/Table Scripts/RofDatamart/dbo.RofRevenueFromServicesCompletedByDate.sql
+++ b/Database/Table Scripts/RofDatamart/dbo.RofRevenueFromServicesCompletedByDate.sql
@@ -1,0 +1,21 @@
+USE [RofDatamart];
+GO
+
+IF (EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'RofRevenueFromServicesCompletedByDate'))
+BEGIN
+	DROP TABLE dbo.RofRevenueFromServicesCompletedByDate;
+END
+
+CREATE TABLE dbo.RofRevenueFromServicesCompletedByDate
+(	
+	EmployeeId BIGINT NOT NULL,
+	EmployeeFirstName VARCHAR(25) NOT NULL,
+	EmployeeLastName VARCHAR(25) NOT NULL,
+	EmployeePay DECIMAL(5,2) NOT NULL,
+	PetServiceId BIGINT NOT NULL,
+	PetServiceName VARCHAR(255) NOT NULL,
+	PetServiceRate DECIMAL(5, 2) NOT NULL,
+	IsHolidayRate BIT NOT NULL,
+	NetRevenuePostEmployeeCut DECIMAL(5,2) NOT NULL,
+	RevenueDate DATE NOT NULL
+);


### PR DESCRIPTION
RofRevenueByDate - table that gives the total revenue. It can give revenue base on a specific date, or specific month (summing up all same month same year revenue), or a specific year (summing up all revenue of a year).

RofRevenueFromServicesCompletedByDate - table gives more detailed look into what services contributed to total revenue for a specific date.